### PR TITLE
fix: Correct parsing of betas environment variable

### DIFF
--- a/scr/utils.py
+++ b/scr/utils.py
@@ -174,7 +174,11 @@ def load_config_from_env(config):
             elif field_type == bool:
                 setattr(config, field_name, field_value.lower() == "true")
             elif field_type == tuple:
-                setattr(config, field_name, tuple(map(field_type, field_value.split(","))))
+                if field_name == "betas":
+                    # Parse the comma-separated values into a tuple of floats
+                    setattr(config, field_name, tuple(map(float, field_value.split(","))))
+                else:
+                    setattr(config, field_name, tuple(map(field_type, field_value.split(","))))
             else:
                 raise ValueError(f"Unsupported field type for {field_name}: {field_type}")
 


### PR DESCRIPTION
The betas environment variable was incorrectly formatted in the environment file, causing it to be loaded as a tuple of strings instead of a tuple of floats. This commit addresses the issue by updating the environment file to use a comma-separated format for betas and modifying the load_config_from_env function in utils.py to correctly parse betas as a tuple of floats 😃 

Add this to you env file in case you want to test AdamW:
betas=0.9,0.999
eps = 1e-08
weight_decay = 0.01
